### PR TITLE
[rewrite] script in pr-comment.yml

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,13 +8,13 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v5
         with:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
             async function upsertComment(owner, repo, issue_number, purpose, body) {
-              const {data: comments} = await github.issues.listComments(
+              const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});
 
               const marker = `<!-- bot: ${purpose} -->`;
@@ -24,14 +24,14 @@ jobs:
               if (existing.length > 0) {
                 const last = existing[existing.length - 1];
                 core.info(`Updating comment ${last.id}`);
-                await github.issues.updateComment({
+                await github.rest.issues.updateComment({
                   owner, repo,
                   body,
                   comment_id: last.id,
                 });
               } else {
                 core.info(`Creating a comment in issue / PR #${issue_number}`);
-                await github.issues.createComment({issue_number, body, owner, repo});
+                await github.rest.issues.createComment({issue_number, body, owner, repo});
               }
             }
 
@@ -43,7 +43,8 @@ jobs:
               return core.error("This workflow doesn't match any pull requests!");
             }
 
-            const {data: {artifacts}} = await github.actions.listWorkflowRunArtifacts({owner, repo, run_id});
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
             if (!artifacts.length) {
               return core.error(`No artifacts found`);
             }

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -37,23 +37,10 @@ jobs:
 
             const {owner, repo} = context.repo;
             const run_id = ${{github.event.workflow_run.id}};
-            const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
-            const pull_user_id = ${{github.event.sender.id}};
 
-            const issue_number = await (async () => {
-              const pulls = await github.pulls.list({owner, repo});
-              for await (const {data} of github.paginate.iterator(pulls)) {
-                for (const pull of data) {
-                  if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
-                    return pull.number;
-                  }
-                }
-              }
-            })();
-            if (issue_number) {
-              core.info(`Using pull request ${issue_number}`);
-            } else {
-              return core.error(`No matching pull request found`);
+            const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
+            if (!pull_requests.length) {
+              return core.error("This workflow doesn't match any pull requests!");
             }
 
             const {data: {artifacts}} = await github.actions.listWorkflowRunArtifacts({owner, repo, run_id});
@@ -65,4 +52,7 @@ jobs:
               body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
             }
 
-            await upsertComment(owner, repo, issue_number, "nightly-link", body);
+            for (const pr of pull_requests) {
+              await upsertComment(owner, repo, pr.number,
+                "nightly-link", body);
+            }

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -13,6 +13,28 @@ jobs:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
+            async function upsertComment(owner, repo, issue_number, purpose, body) {
+              const {data: comments} = await github.issues.listComments(
+                {owner, repo, issue_number});
+
+              const marker = `<!-- bot: ${purpose} -->`;
+              body = marker + "\n" + body;
+
+              const existing = comments.filter((c) => c.body.includes(marker));
+              if (existing.length > 0) {
+                const last = existing[existing.length - 1];
+                core.info(`Updating comment ${last.id}`);
+                await github.issues.updateComment({
+                  owner, repo,
+                  body,
+                  comment_id: last.id,
+                });
+              } else {
+                core.info(`Creating a comment in issue / PR #${issue_number}`);
+                await github.issues.createComment({issue_number, body, owner, repo});
+              }
+            }
+
             const {owner, repo} = context.repo;
             const run_id = ${{github.event.workflow_run.id}};
             const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
@@ -43,12 +65,4 @@ jobs:
               body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
             }
 
-            const {data: comments} = await github.issues.listComments({repo, owner, issue_number});
-            const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
-            if (existing_comment) {
-              core.info(`Updating comment ${existing_comment.id}`);
-              await github.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});
-            } else {
-              core.info(`Creating a comment`);
-              await github.issues.createComment({repo, owner, issue_number, body});
-            }
+            await upsertComment(owner, repo, issue_number, "nightly-link", body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -53,6 +53,8 @@ jobs:
               body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
             }
 
+            core.info("Review thread message body:", body);
+
             for (const pr of pull_requests) {
               await upsertComment(owner, repo, pr.number,
                 "nightly-link", body);


### PR DESCRIPTION
- Use `actions/github-script@v5` i.e. remove all semicolons ☺
- Support multiple bots chatting into the same review PR, by tagging “our” message with a unique HTML comment (for compatibility with e.g. [EnricoMi/publish-unit-test-result-action](https://github.com/EnricoMi/publish-unit-test-result-action))
- Rather than enumerating PRs through the API and matching them with a fragile algorithm (which fails e.g. when someone else pushes into the same PR branch), use `toJSON(github.event.workflow_run.pull_requests)`which already contains exactly the matching PRs (of which there is typically exactly one)
- More logging